### PR TITLE
Ibm dex

### DIFF
--- a/istio/oidc-authservice/base/kustomization.yaml
+++ b/istio/oidc-authservice/base/kustomization.yaml
@@ -15,64 +15,9 @@ configMapGenerator:
   - params.env
 generatorOptions:
   disableNameSuffixHash: true
-
+configurations:
+- params.yaml
 vars:
-- name: client_id
-  objref:
-    kind: ConfigMap
-    name: oidc-authservice-parameters
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.client_id
-- name: oidc_provider
-  objref:
-    kind: ConfigMap
-    name: oidc-authservice-parameters
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.oidc_provider
-- name: oidc_redirect_uri
-  objref:
-    kind: ConfigMap
-    name: oidc-authservice-parameters
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.oidc_redirect_uri
-- name: oidc_auth_url
-  objref:
-    kind: ConfigMap
-    name: oidc-authservice-parameters
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.oidc_auth_url
-- name: application_secret
-  objref:
-    kind: ConfigMap
-    name: oidc-authservice-parameters
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.application_secret
-- name: skip_auth_uri
-  objref:
-    kind: ConfigMap
-    name: oidc-authservice-parameters
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.skip_auth_uri
-- name: userid-header
-  objref:
-    kind: ConfigMap
-    name: oidc-authservice-parameters
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.userid-header
-- name: userid-prefix
-  objref:
-    kind: ConfigMap
-    name: oidc-authservice-parameters
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.userid-prefix
 - name: namespace
   objref:
     kind: ConfigMap
@@ -80,8 +25,6 @@ vars:
     apiVersion: v1
   fieldref:
     fieldpath: data.namespace
-configurations:
-- params.yaml
 images:
 - name: gcr.io/arrikto/kubeflow/oidc-authservice
   newName: gcr.io/arrikto/kubeflow/oidc-authservice

--- a/istio/oidc-authservice/base/params.yaml
+++ b/istio/oidc-authservice/base/params.yaml
@@ -1,6 +1,4 @@
 varReference:
-- path: spec/template/spec/containers/env/value
-  kind: StatefulSet
 - path: spec/filters/filterConfig/httpService/serverUri/uri
   kind: EnvoyFilter
 - path: spec/filters/filterConfig/httpService/serverUri/cluster

--- a/istio/oidc-authservice/base/statefulset.yaml
+++ b/istio/oidc-authservice/base/statefulset.yaml
@@ -23,30 +23,54 @@ spec:
         - name: http-api
           containerPort: 8080
         env:
-          - name: USERID_HEADER
-            value: $(userid-header)
-          - name: USERID_PREFIX
-            value: $(userid-prefix)
-          - name: USERID_CLAIM
-            value: email
-          - name: OIDC_PROVIDER
-            value: $(oidc_provider)
-          - name: OIDC_AUTH_URL
-            value: $(oidc_auth_url)
-          - name: OIDC_SCOPES
-            value: "profile email groups"
-          - name: REDIRECT_URL
-            value: $(oidc_redirect_uri)
-          - name: SKIP_AUTH_URI
-            value: $(skip_auth_uri)
-          - name: PORT
-            value: "8080"
-          - name: CLIENT_ID
-            value: $(client_id)
-          - name: CLIENT_SECRET
-            value: $(application_secret)
-          - name: STORE_PATH
-            value: /var/lib/authservice/data.db
+        - name: USERID_HEADER
+          valueFrom:
+            configMapKeyRef:
+              name: oidc-authservice-parameters
+              key: userid-header
+        - name: USERID_PREFIX
+          valueFrom:
+            configMapKeyRef:
+              name: oidc-authservice-parameters
+              key: userid-prefix
+        - name: USERID_CLAIM
+          value: email
+        - name: OIDC_PROVIDER
+          valueFrom:
+            configMapKeyRef:
+              name: oidc-authservice-parameters
+              key: oidc_provider
+        - name: OIDC_AUTH_URL
+          valueFrom:
+            configMapKeyRef:
+              name: oidc-authservice-parameters
+              key: oidc_auth_url
+        - name: OIDC_SCOPES
+          value: "profile email groups"
+        - name: REDIRECT_URL
+          valueFrom:
+            configMapKeyRef:
+              name: oidc-authservice-parameters
+              key: oidc_redirect_uri
+        - name: SKIP_AUTH_URI
+          valueFrom:
+            configMapKeyRef:
+              name: oidc-authservice-parameters
+              key: skip_auth_uri
+        - name: PORT
+          value: "8080"
+        - name: CLIENT_ID
+          valueFrom:
+            configMapKeyRef:
+              name: oidc-authservice-parameters
+              key: client_id
+        - name: CLIENT_SECRET
+          valueFrom:
+            configMapKeyRef:
+              name: oidc-authservice-parameters
+              key: application_secret
+        - name: STORE_PATH
+          value: /var/lib/authservice/data.db
         volumeMounts:
           - name: data
             mountPath: /var/lib/authservice

--- a/stacks/ibm/application/oidc-authservice/kustomization.yaml
+++ b/stacks/ibm/application/oidc-authservice/kustomization.yaml
@@ -10,58 +10,16 @@ resources:
 generatorOptions:
   disableNameSuffixHash: true
 configMapGenerator:
-- name: oidc-authservice-config
+- name: oidc-authservice-parameters
   envs:
   - params.env
 configurations:
 - params.yaml
 vars:
-- name: client_id
-  objref:
-    kind: ConfigMap
-    name: oidc-authservice-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.client_id
-- name: oidc_provider
-  objref:
-    kind: ConfigMap
-    name: oidc-authservice-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.oidc_provider
-- name: oidc_redirect_uri
-  objref:
-    kind: ConfigMap
-    name: oidc-authservice-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.oidc_redirect_uri
-- name: oidc_auth_url
-  objref:
-    kind: ConfigMap
-    name: oidc-authservice-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.oidc_auth_url
-- name: application_secret
-  objref:
-    kind: ConfigMap
-    name: oidc-authservice-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.application_secret
-- name: skip_auth_uri
-  objref:
-    kind: ConfigMap
-    name: oidc-authservice-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.skip_auth_uri
 - name: namespace
   objref:
     kind: ConfigMap
-    name: oidc-authservice-config
+    name: oidc-authservice-parameters
     apiVersion: v1
   fieldref:
     fieldpath: data.namespace

--- a/stacks/ibm/application/oidc-authservice/params.env
+++ b/stacks/ibm/application/oidc-authservice/params.env
@@ -3,5 +3,7 @@ oidc_provider=http://dex.auth.svc.cluster.local:5556/dex
 oidc_redirect_uri=/login/oidc
 oidc_auth_url=/dex/auth
 application_secret=
+userid-header=kubeflow-userid
+userid-prefix=
 skip_auth_uri=/dex
 namespace=istio-system

--- a/stacks/ibm/application/oidc-authservice/params.yaml
+++ b/stacks/ibm/application/oidc-authservice/params.yaml
@@ -1,6 +1,4 @@
 varReference:
-- path: spec/template/spec/containers/env/value
-  kind: StatefulSet
 - path: spec/filters/filterConfig/httpService/serverUri/uri
   kind: EnvoyFilter
 - path: spec/filters/filterConfig/httpService/serverUri/cluster

--- a/stacks/ibm/application/oidc-authservice/statefulset-patch.yaml
+++ b/stacks/ibm/application/oidc-authservice/statefulset-patch.yaml
@@ -13,16 +13,3 @@ spec:
         volumeMounts:
         - mountPath: /var/lib/authservice
           name: data
-      containers:
-      - name: authservice
-        env:
-        - name: USERID_HEADER
-          valueFrom:
-            configMapKeyRef:
-              name: kubeflow-config
-              key: userid-header
-        - name: USERID_PREFIX
-          valueFrom:
-            configMapKeyRef:
-              name: kubeflow-config
-              key: userid-prefix


### PR DESCRIPTION
I've made several changes:

1. uses configMapKeyRef for sts `authservice` so that it can pick up configmap changes during runtime after running `kfctl apply -f kfctl_ibm_dex.yaml`
1. hard-coded `userid_header` since it can not load such global config from a configmap `kubeflow-config` in another namespace.

This is the `dex-config.yaml` I used:

```YAML
apiVersion: v1
kind: ConfigMap
metadata:
  name: dex
  namespace: auth
data:
  config.yaml: |
    issuer: http://dex.auth.svc.cluster.local:5556/dex
    storage:
      type: kubernetes
      config:
        inCluster: true
    web:
      http: 0.0.0.0:5556
    logger:
      level: "debug"
      format: text
    connectors:
      - type: github
        # Required field for connector id.
        id: github
        # Required field for connector name.
        name: GitHub
        config:
          # Credentials can be string literals or pulled from the environment.
          clientID: <client_id_from_github_auth_app>
          clientSecret: <client_secret_from_github_auth_app>
          redirectURI: http://dex.auth.svc.cluster.local:5556/dex/callback
          # Optional organizations and teams, communicated through the "groups" scope.
          #
          # NOTE: This is an EXPERIMENTAL config option and will likely change.
          #
          orgs:
          - name: pipedream
          # Required ONLY for GitHub Enterprise. Leave it empty when using github.com.
          # This is the Hostname of the GitHub Enterprise account listed on the
          # management console. Ensure this domain is routable on your network.
          hostName:
          # Flag which indicates that all user groups and teams should be loaded.
          loadAllGroups: false
          # flag which will switch from using the internal GitHub id to the users handle (@mention) as the user id.
          # It is possible for a user to change their own user name but it is very rare for them to do so
          useLoginAsID: false
    staticClients:
    - id: kubeflow-oidc-authservice
      redirectURIs: ["/login/oidc"]
      name: 'Dex Login Application'
      secret: <a-secret-matches-that-from-below-application_secret>
---
apiVersion: v1
kind: ConfigMap
metadata:
  name: oidc-authservice-parameters
  namespace: istio-system
data:
  application_secret: <a-secret-string>
  client_id: kubeflow-oidc-authservice
  namespace: istio-system
  oidc_auth_url: /dex/auth
  oidc_provider: http://dex.auth.svc.cluster.local:5556/dex
  oidc_redirect_uri: /login/oidc
  skip_auth_uri: /dex
  userid-header: kubeflow-userid
  userid-prefix: ""
```

## Steps after running `kfctl apply -f kfctl_ibm_dex.yaml`:

```SHELL
$ kubectl apply -f dex-config.yaml
$ kubectl rollout restart deploy/dex -n auth
$ kubectl delete pod authservice-0 -n istio-system
```

Then it works. Let's talk about it next monday